### PR TITLE
Ellipsis menu added

### DIFF
--- a/frontend/src/components/dropdowns/CustomerEllipsis.tsx
+++ b/frontend/src/components/dropdowns/CustomerEllipsis.tsx
@@ -1,0 +1,45 @@
+import { Dropdown } from "react-bootstrap";
+import { IoEllipsisVertical } from "react-icons/io5";
+import { RiDirectionLine, RiFlagLine, RiInformationLine } from "react-icons/ri";
+import { SlSupport } from "react-icons/sl";
+
+interface Props {
+  address: string;
+}
+
+const CustomerEllipsis = ({ address }: Props) => {
+  return (
+    <Dropdown className='dropdown-ellipsis-container'>
+      <Dropdown.Toggle className='dropdown-ellipsis'>
+        <IoEllipsisVertical size={28} />
+      </Dropdown.Toggle>
+
+      <Dropdown.Menu>
+        <Dropdown.Item
+          className='d-flex align-items-center'
+          href={`https://maps.apple.com/?q=${address}`}
+          target='_blank'
+        >
+          <RiDirectionLine className='me-2' size={24} />
+          <span>Vägbeskrivning</span>
+        </Dropdown.Item>
+        <Dropdown.Divider />
+        <Dropdown.Item className='d-flex align-items-center' href='#'>
+          <RiInformationLine className='me-2' size={24} />
+          <span>Kundinformation</span>
+        </Dropdown.Item>
+        <Dropdown.Divider />
+        <Dropdown.Item className='d-flex align-items-center' href='#'>
+          <SlSupport className='me-2' size={24} />
+          <span>Be om hjälp</span>
+        </Dropdown.Item>
+        <Dropdown.Item className='d-flex align-items-center' href='#'>
+          <RiFlagLine className='me-2' size={24} />
+          <span>Rapportera fel</span>
+        </Dropdown.Item>
+      </Dropdown.Menu>
+    </Dropdown>
+  );
+};
+
+export default CustomerEllipsis;

--- a/frontend/src/pages/Customer.tsx
+++ b/frontend/src/pages/Customer.tsx
@@ -3,9 +3,11 @@ import { BsChevronLeft } from "react-icons/bs";
 import { useQuery } from "react-query";
 import { useNavigate, useParams } from "react-router-dom";
 import ChoreCard from "../components/ChoreCard";
+import CustomerEllipsis from "../components/dropdowns/CustomerEllipsis";
 import CustomerPageSkeleton from "../components/skeletons/CustomerPageSkeleton";
 import useAxios from "../hooks/useAxios";
 import { CustomerChore } from "../models/CustomerChore";
+
 const Customer = () => {
   const { id } = useParams();
   const navigate = useNavigate();
@@ -35,8 +37,9 @@ const Customer = () => {
           </div>
           <Container>
             <div className='h3 mb-0'>{data[0].customer.name}</div>
-            <div className='p'>{data[0].customer.address}</div>
+            <div className='p mb-1'>{data[0].customer.address}</div>
           </Container>
+          <CustomerEllipsis address={data[0].customer.address} />
         </div>
         {data.map((data) => (
           <ChoreCard key={data.id} customerchore={data} />

--- a/frontend/src/styling/overrides.scss
+++ b/frontend/src/styling/overrides.scss
@@ -172,10 +172,34 @@
   }
 }
 
-.card, .btn, .modal-content, form > div, .progress {
+.card,
+.btn,
+.modal-content,
+form>div,
+.progress,
+.dropdown-menu {
   border-radius: 2px !important;
 }
 
+.dropdown-ellipsis-container {
+  .dropdown-toggle::after {
+    all: unset;
+  }
+
+  .dropdown-ellipsis {
+    all: unset;
+
+    &:hover {
+      all: unset;
+      cursor: pointer;
+    }
+  }
+
+  .btn.show {
+    background: transparent !important;
+    color: var(--bs-primary);
+  }
+}
 // NavLink overrides
 .router-link {
   color: inherit;


### PR DESCRIPTION
close #179 
Added an ellipsis menu to the customer page where we can add stuff like report errors, customer info etc, just to demonstrate what it might look like I added them in aswell: 
![bild](https://user-images.githubusercontent.com/90825872/211123170-43184dab-ee9d-4212-995a-6dc41532fd64.png)

The only functional link is the navigation menu item which opens maps on android/ios